### PR TITLE
Added support for math rendering

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,5 +14,8 @@
 <script src="{{ "assets/main.js" | absURL }}"></script>
 <script src="{{ "assets/prism.js" | absURL }}"></script>
 
+<!-- Support for MathJax math rendering-->
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
 <!-- Extended footer section-->
 {{ partial "extended_footer.html" . }}


### PR DESCRIPTION
[here](https://gohugo.io/content-management/formats/#enable-mathjax) is the Hugo docs for this. Since the footer is applied to every page, now inline math works!
![DeepinScreenshot_select-area_20190615151007](https://user-images.githubusercontent.com/32942052/59556888-b9a92780-8f7f-11e9-98be-055f5f0fe2ad.png)
